### PR TITLE
fill land with specified color in AACGM coordinates

### DIFF
--- a/examples/demo_dmsp_ssusi_single_panel.py
+++ b/examples/demo_dmsp_ssusi_single_panel.py
@@ -74,7 +74,9 @@ def test_ssusi():
     panel.overlay_gridlines(lat_res=5, lon_label_separator=5)
 
     # Overlay the coastlines in the AACGM coordinate
-    panel.overlay_coastlines()
+    #panel.overlay_coastlines()
+    # Fill land area in the AACGM coordinate
+    panel.overlay_lands( edge_color=None, fill_color='tan', zorder=1, alpha=0.3 )
 
     # Overlay cross-track velocity along satellite trajectory
     sc_dt = ds_s1['SC_DATETIME'].value.flatten()


### PR DESCRIPTION
This PR enhances the overlay_lands method to support filling land area when using non-GEO coordinate systems (self.cs != 'GEO'). Previously, land overlays relied on standard geographic projections; this update introduces a manual transformation pipeline using PolyCollection.

Key Changes
1) Implemented a workflow to fetch Natural Earth land geometries and pass them through self.cs_transform.

2) Use shapely.ops.orient to force CCW (counter-clockwise) orientation, ensuring PolyCollection fills the interior of landmasses rather than the ocean.

3) Added an area-based check (area > 150 * 90) to detect and flip polygons that have been inverted due to projection singularities.

4) Detect and skip "ghost" polygons—stretched artifacts caused by longitude wrapping (0°/360° jumps) .

5) Use matplotlib.collections.PolyCollection for batch rendering of geometries, significantly improving performance over individual polygon plotting.